### PR TITLE
fix(cli): make inspect_ai.analysis imports lazy and improve code quality

### DIFF
--- a/src/evals/__init__.py
+++ b/src/evals/__init__.py
@@ -14,20 +14,8 @@ __all__ = [
 
 def __getattr__(name: str):
     """Lazy import benchmark modules."""
-    if name == "telelogs":
-        from evals import telelogs as mod
+    if name in __all__:
+        import importlib
 
-        return mod
-    if name == "telemath":
-        from evals import telemath as mod
-
-        return mod
-    if name == "teleqna":
-        from evals import teleqna as mod
-
-        return mod
-    if name == "three_gpp":
-        from evals import three_gpp as mod
-
-        return mod
+        return importlib.import_module(f".{name}", __name__)
     raise AttributeError(f"module 'evals' has no attribute {name!r}")

--- a/src/evals/cli/screens/preview_leaderboard/preview_leaderboard_screen.py
+++ b/src/evals/cli/screens/preview_leaderboard/preview_leaderboard_screen.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pandas as pd
-from inspect_ai.analysis import evals_df
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -205,6 +204,9 @@ class PreviewLeaderboardScreen(BaseScreen):
 
     def _load_from_json_logs(self, log_dir: Path) -> list[LeaderboardEntry]:
         try:
+            # Import lazily to avoid terminal interference (see PR #14)
+            from inspect_ai.analysis import evals_df
+
             df = evals_df(str(log_dir), quiet=True)
         except Exception:
             return []

--- a/src/evals/cli/screens/run_evals/run_evals_screen.py
+++ b/src/evals/cli/screens/run_evals/run_evals_screen.py
@@ -11,7 +11,6 @@ from enum import Enum
 from pathlib import Path
 
 import pandas as pd
-from inspect_ai.analysis import evals_df
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -621,6 +620,9 @@ class EvalRunningScreen(Screen[bool]):
     def _export_to_leaderboard_parquet(
         self, log_dir: str, output_path: str
     ) -> pd.DataFrame:
+        # Import lazily to avoid terminal interference (see PR #14)
+        from inspect_ai.analysis import evals_df
+
         df = evals_df(log_dir, quiet=True)
 
         if df.empty:
@@ -1569,6 +1571,9 @@ class RunEvalsScreen(Screen[None]):
     def _export_to_leaderboard_parquet(
         self, log_dir: str, output_path: str
     ) -> pd.DataFrame:
+        # Import lazily to avoid terminal interference (see PR #14)
+        from inspect_ai.analysis import evals_df
+
         df = evals_df(log_dir, quiet=True)
 
         if df.empty:

--- a/src/evals/cli/screens/submit/submit_screen.py
+++ b/src/evals/cli/screens/submit/submit_screen.py
@@ -6,7 +6,6 @@ from enum import Enum
 from pathlib import Path
 
 import pandas as pd
-from inspect_ai.analysis import evals_df
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -264,6 +263,9 @@ class SubmitScreen(BaseScreen):
             Tuple of (LeaderboardEntry list, models_data dict for building final model list)
         """
         try:
+            # Import lazily to avoid terminal interference (see PR #14)
+            from inspect_ai.analysis import evals_df
+
             df = evals_df(str(log_dir), quiet=True)
         except Exception:
             return [], {}

--- a/src/evals/cli/screens/submit/trajectory_bundler.py
+++ b/src/evals/cli/screens/submit/trajectory_bundler.py
@@ -9,7 +9,6 @@ from datetime import date
 from pathlib import Path
 
 import pandas as pd
-from inspect_ai.analysis import evals_df
 
 from evals.cli.types import Result
 
@@ -127,6 +126,9 @@ def _generate_parquet_from_logs(
     Returns:
         Parquet file content as bytes
     """
+    # Import lazily to avoid terminal interference (see PR #14)
+    from inspect_ai.analysis import evals_df
+
     df = evals_df(str(log_dir), quiet=True)
 
     if df.empty:

--- a/src/evals/cli/utils/process.py
+++ b/src/evals/cli/utils/process.py
@@ -41,7 +41,7 @@ def communicate_with_timeout(
         return stdout, stderr, False
     except subprocess.TimeoutExpired:
         process.kill()
-        process.wait()
+        process.communicate()  # Drain pipes to avoid potential deadlock
         return "", "", True
 
 


### PR DESCRIPTION
## Summary
Fixes issues identified in code review of PR #17.

Fixes #17 (code review follow-up)

## Changes Made
- Move `inspect_ai.analysis` imports inside functions to prevent terminal interference (reapplies fix from PR #14 to new CLI screens)
- Simplify `__init__.py` lazy loading using `importlib.import_module()`
- Use `communicate()` instead of `wait()` after `process.kill()` to properly drain pipes

## Files Modified
- `src/open_telco/__init__.py` - Simplified lazy loading pattern
- `src/open_telco/cli/screens/preview_leaderboard/preview_leaderboard_screen.py` - Lazy import
- `src/open_telco/cli/screens/run_evals/run_evals_screen.py` - Lazy imports (2 locations)
- `src/open_telco/cli/screens/submit/submit_screen.py` - Lazy import
- `src/open_telco/cli/screens/submit/trajectory_bundler.py` - Lazy import
- `src/open_telco/cli/utils/process.py` - Fix resource leak

## Test Plan
- [ ] Run `uv run pytest` to verify all tests pass
- [ ] Run `uv run ruff check` to verify linting passes
- [ ] Run the CLI to verify terminal rendering is not affected

---
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>