### PR TITLE
fix(registry): Add missing teletables to __init__.__all__

### DIFF
--- a/src/evals/__init__.py
+++ b/src/evals/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "telelogs",
     "telemath",
     "teleqna",
+    "teletables",
     "three_gpp",
 ]
 


### PR DESCRIPTION
Closes #35

## Summary
- Add missing `teletables` to `__all__` in `src/evals/__init__.py`
- `teletables` was present in `_registry.py` but missing from `__init__.py`, making it undiscoverable via the package's public API and breaking the leaderboard's dynamic benchmark registry

## Test plan
- [x] Verify `from evals import teletables` works
- [x] Verify `__all__` matches `_registry.py`'s `__all__`

🤖 Generated with [Claude Code](https://claude.com/claude-code)