### PR TITLE
feat: Add ORANBench and srsRANBench evaluations

### DIFF
--- a/docs/eval-list.md
+++ b/docs/eval-list.md
@@ -11,6 +11,8 @@ This page lists all available benchmarks in Open Telco. Each benchmark tests dif
 | [TeleMath](#telemath) | Math Reasoning | Hard | Mathematical/analytical tasks |
 | [TeleLogs](#telelogs) | Operations | Medium | Network diagnostics use cases |
 | [3GPP TSG](#3gpp-tsg) | Standards | Medium | Standards document work |
+| [ORANBench](#oranbench) | Standards | Medium | O-RAN architecture and specs |
+| [srsRANBench](#srsranbench) | Code Understanding | Medium | srsRAN codebase comprehension |
 | TeleYAML | Configuration | Hard | Network automation (coming soon) |
 
 **Recommended starting point**: TeleQnA - fastest to run and provides good baseline metrics.
@@ -92,3 +94,30 @@ uv run inspect eval src/evals/three_gpp/three_gpp.py --model <model>
 ```
 
 [Dataset](https://huggingface.co/datasets/eaguaida/gsma_sample)
+
+### ORANBench
+
+**[ORANBench](../src/evals/oranbench/)**: Assessing LLM Understanding of Open Radio Access Networks
+
+1,500 multiple-choice questions derived from 116 O-RAN Alliance specification documents, stratified across 3 difficulty levels (500 easy, 500 medium, 500 hard). A curated subset of the ORAN-Bench-13K dataset covering O-RAN architecture components (O-RU, O-DU, O-CU, RIC), fronthaul interfaces, E2 node configurations, and management/orchestration.
+
+```bash
+uv run inspect eval src/evals/oranbench/oranbench.py --model <model>
+
+# Filter by difficulty
+uv run inspect eval src/evals/oranbench/oranbench.py --model <model> -T difficulty=hard
+```
+
+[Paper](https://arxiv.org/abs/2407.06245) | [Dataset](https://huggingface.co/datasets/prnshv/ORANBench)
+
+### srsRANBench
+
+**[srsRANBench](../src/evals/srsranbench/)**: Assessing LLM Understanding of the srsRAN 5G Codebase
+
+1,502 multiple-choice questions testing LLM comprehension of the srsRAN Project — an open-source 5G RAN implementation in C++. Questions cover classes, functions, libraries, configurations, and 3GPP specification details as implemented in srsRAN.
+
+```bash
+uv run inspect eval src/evals/srsranbench/srsranbench.py --model <model>
+```
+
+[Paper](https://arxiv.org/abs/2407.06245) | [Dataset](https://huggingface.co/datasets/prnshv/srsRANBench)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -41,6 +41,8 @@ uv run inspect eval src/evals/teleqna/teleqna.py --model openai/gpt-4o --limit 5
 | **TeleMath** | Mathematical reasoning in telecom | Signal processing, network optimization |
 | **TeleLogs** | Root cause analysis | Network operations, diagnostics |
 | **3GPP TSG** | Standards document understanding | Technical specification work |
+| **ORANBench** | O-RAN specifications knowledge | O-RAN architecture, interfaces, protocols |
+| **srsRANBench** | srsRAN codebase understanding | Open-source 5G RAN code comprehension |
 | **TeleYAML** | Configuration generation | Network automation tasks |
 
 ### How do I interpret results?
@@ -61,6 +63,8 @@ Scores vary by benchmark complexity:
 | TeleLogs | 30-60% | Requires reasoning about network state |
 | TeleMath | 20-50% | Complex multi-step calculations |
 | 3GPP TSG | 50-80% | Document classification |
+| ORANBench | 40-70% | Multiple choice, O-RAN domain |
+| srsRANBench | 30-60% | Multiple choice, code understanding |
 
 ## Running Evaluations
 
@@ -73,6 +77,8 @@ Depends on the benchmark, model, and sample count:
 | TeleQnA | ~2-5 min | ~30-60 min |
 | TeleLogs | ~5-10 min | ~1-2 hours |
 | TeleMath | ~10-20 min | ~2-4 hours |
+| ORANBench | ~2-5 min | ~20-40 min |
+| srsRANBench | ~2-5 min | ~20-40 min |
 
 Use `--limit N` to run fewer samples for testing.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -72,6 +72,12 @@ uv run inspect eval src/evals/telelogs/telelogs.py --model openai/gpt-4o --limit
 
 # Standards classification
 uv run inspect eval src/evals/three_gpp/three_gpp.py --model openai/gpt-4o --limit 10
+
+# O-RAN specifications knowledge
+uv run inspect eval src/evals/oranbench/oranbench.py --model openai/gpt-4o --limit 10
+
+# srsRAN codebase understanding
+uv run inspect eval src/evals/srsranbench/srsranbench.py --model openai/gpt-4o --limit 10
 ```
 
 ## Try Different Models

--- a/docs/running-evaluations.md
+++ b/docs/running-evaluations.md
@@ -41,7 +41,7 @@ uv run inspect view
 
 ## Full Benchmarks
 
-By default, evaluations run on **small samples** from `GSMA/ot_sample_data` (100 samples each, 1000 for TeleQnA). To run on the **full benchmark datasets** from `GSMA/ot-full-benchmarks`, use the `full` parameter.
+By default, evaluations run on **small samples** from `GSMA/ot_sample_data` (100–150 samples each, 1,000 for TeleQnA). To run on the **full benchmark datasets** from `GSMA/ot-full-benchmarks`, use the `full` parameter.
 
 ### Single Evaluation
 
@@ -78,11 +78,13 @@ uv run inspect eval-set src/evals/teleqna/teleqna.py src/evals/telemath/telemath
 
 | Dataset | Small samples | Full samples |
 |---------|--------------|--------------|
-| TeleQnA | 1,000 | ~10,000 |
-| TeleTables | 100 | ~500 |
-| TeleMath | 100 | ~500 |
+| TeleQnA | 1,000 | 10,000 |
+| TeleTables | 100 | 500 |
+| TeleMath | 100 | 500 |
 | TeleLogs | 100 | 500 |
-| 3GPP TSG | 100 | 100 |
+| 3GPP TSG | 100 | 2,000 |
+| ORANBench | 150 | 1,500 |
+| srsRANBench | 150 | 1,502 |
 
 ---
 
@@ -110,7 +112,9 @@ success, logs = eval_set(
       "telelogs/telelogs.py",
       "three_gpp/three_gpp.py",
       "teleqna/teleqna.py",
-      "telemath/telemath.py"
+      "telemath/telemath.py",
+      "oranbench/oranbench.py",
+      "srsranbench/srsranbench.py"
    ],
    model=[
       "openai/gpt-4o",

--- a/src/evals/__init__.py
+++ b/src/evals/__init__.py
@@ -5,6 +5,8 @@ Use: from evals.telelogs import telelogs
 """
 
 __all__ = [
+    "oranbench",
+    "srsranbench",
     "telelogs",
     "telemath",
     "teleqna",

--- a/src/evals/_registry.py
+++ b/src/evals/_registry.py
@@ -1,3 +1,5 @@
+from evals.oranbench.oranbench import oranbench
+from evals.srsranbench.srsranbench import srsranbench
 from evals.telelogs.telelogs import telelogs
 from evals.telemath.telemath import telemath
 from evals.teleqna.teleqna import teleqna
@@ -5,6 +7,8 @@ from evals.teletables.teletables import teletables
 from evals.three_gpp.three_gpp import three_gpp
 
 __all__ = [
+    "oranbench",
+    "srsranbench",
     "telelogs",
     "telemath",
     "teleqna",

--- a/src/evals/oranbench/README.md
+++ b/src/evals/oranbench/README.md
@@ -1,0 +1,59 @@
+```
+ ██████╗ ██████╗  █████╗ ███╗   ██╗██████╗ ███████╗███╗   ██╗ ██████╗██╗  ██╗
+██╔═══██╗██╔══██╗██╔══██╗████╗  ██║██╔══██╗██╔════╝████╗  ██║██╔════╝██║  ██║
+██║   ██║██████╔╝███████║██╔██╗ ██║██████╔╝█████╗  ██╔██╗ ██║██║     ███████║
+██║   ██║██╔══██╗██╔══██║██║╚██╗██║██╔══██╗██╔══╝  ██║╚██╗██║██║     ██╔══██║
+╚██████╔╝██║  ██║██║  ██║██║ ╚████║██████╔╝███████╗██║ ╚████║╚██████╗██║  ██║
+ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝╚═════╝ ╚══════╝╚═╝  ╚═══╝ ╚═════╝╚═╝  ╚═╝
+```
+
+Evaluating LLM Understanding of O-RAN Specifications and Architecture.
+
+## Overview
+
+1,500 multiple-choice questions derived from 116 O-RAN Alliance specification documents, stratified across 3 difficulty levels:
+
+| Difficulty | Questions | Description |
+|------------|-----------|-------------|
+| Easy | 500 | Foundational O-RAN concepts and terminology |
+| Medium | 500 | Intermediate architecture and protocol questions |
+| Hard | 500 | Advanced specification details and functional splits |
+
+## Usage
+
+```bash
+uv run inspect eval src/evals/oranbench/oranbench.py --model openai/gpt-4o
+```
+
+Filter by difficulty using the `difficulty` parameter:
+```bash
+uv run inspect eval src/evals/oranbench/oranbench.py --model openai/gpt-4o -T difficulty=hard
+```
+
+## Scoring
+
+Each question has one correct answer from 4 choices. The model's response is compared against the target answer using exact match.
+
+**Reference performance:** RAG-based ORANSight achieves ~78% on the full ORAN-Bench-13K; general-purpose LLMs score 21-23% lower.
+
+## Metrics
+
+- **accuracy**: Fraction of correct answers
+- **stderr**: Standard error of the accuracy estimate
+
+## Dataset Structure
+
+Each record contains:
+
+| Field | Description |
+|-------|-------------|
+| `question` | Multiple-choice question about O-RAN specs |
+| `choices` | List of 4 answer candidates |
+| `answer` | Index (0-3) of correct answer |
+| `difficulty` | Question difficulty: easy, medium, or hard |
+
+## Links
+
+- [Paper](https://arxiv.org/abs/2407.06245)
+- [Dataset](https://huggingface.co/datasets/prnshv/ORANBench)
+- [GitHub](https://github.com/prnshv/ORAN-Bench-13K)

--- a/src/evals/oranbench/__init__.py
+++ b/src/evals/oranbench/__init__.py
@@ -1,0 +1,3 @@
+from evals.oranbench.oranbench import oranbench
+
+__all__ = ["oranbench"]

--- a/src/evals/oranbench/oranbench.py
+++ b/src/evals/oranbench/oranbench.py
@@ -1,0 +1,47 @@
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample, hf_dataset
+from inspect_ai.scorer import choice
+from inspect_ai.solver import multiple_choice
+
+from evals._utils import resolve_dataset
+
+DEFAULT_DIFFICULTY = "full"
+DEFAULT_DATASET = "GSMA/ot_sample_data"
+DEFAULT_DATASET_NAME = "oranbench"
+DEFAULT_SPLIT = "test"
+
+
+def record_to_sample(record: dict) -> Sample:
+    """Convert dataset record to Sample with difficulty metadata."""
+    return Sample(
+        input=record["question"],
+        choices=record["choices"],
+        target=chr(65 + record["answer"]),
+        metadata={"difficulty": record.get("difficulty")},
+    )
+
+
+@task
+def oranbench(
+    difficulty: str = DEFAULT_DIFFICULTY,
+    dataset_path: str = DEFAULT_DATASET,
+    split: str = DEFAULT_SPLIT,
+    full: bool = False,
+) -> Task:
+    ds_path, ds_split = resolve_dataset(full, dataset_path, DEFAULT_DATASET, split)
+    dataset = hf_dataset(
+        ds_path,
+        name=DEFAULT_DATASET_NAME,
+        sample_fields=record_to_sample,
+        split=ds_split,
+    )
+    if difficulty != DEFAULT_DIFFICULTY:
+        dataset = dataset.filter(
+            lambda sample: sample.metadata is not None
+            and sample.metadata.get("difficulty") == difficulty
+        )
+    return Task(
+        dataset=dataset,
+        solver=multiple_choice(cot=False),
+        scorer=choice(),
+    )

--- a/src/evals/run_evals.py
+++ b/src/evals/run_evals.py
@@ -24,6 +24,8 @@ if __name__ == "__main__":
             "three_gpp/three_gpp.py",
             "teleqna/teleqna.py",
             "telemath/telemath.py",
+            "oranbench/oranbench.py",
+            "srsranbench/srsranbench.py",
         ],  # set how many tasks you want to run
         model=[
             "openrouter/openai/gpt-5.2",

--- a/src/evals/srsranbench/README.md
+++ b/src/evals/srsranbench/README.md
@@ -1,0 +1,47 @@
+```
+███████╗██████╗ ███████╗██████╗  █████╗ ███╗   ██╗██████╗ ███████╗███╗   ██╗ ██████╗██╗  ██╗
+██╔════╝██╔══██╗██╔════╝██╔══██╗██╔══██╗████╗  ██║██╔══██╗██╔════╝████╗  ██║██╔════╝██║  ██║
+███████╗██████╔╝███████╗██████╔╝███████║██╔██╗ ██║██████╔╝█████╗  ██╔██╗ ██║██║     ███████║
+╚════██║██╔══██╗╚════██║██╔══██╗██╔══██║██║╚██╗██║██╔══██╗██╔══╝  ██║╚██╗██║██║     ██╔══██║
+███████║██║  ██║███████║██║  ██║██║  ██║██║ ╚████║██████╔╝███████╗██║ ╚████║╚██████╗██║  ██║
+╚══════╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝╚═════╝ ╚══════╝╚═╝  ╚═══╝ ╚═════╝╚═╝  ╚═╝
+```
+
+Evaluating LLM Understanding of the srsRAN 5G Open-Source Codebase.
+
+## Overview
+
+1,502 multiple-choice questions testing LLM comprehension of the srsRAN Project codebase — an open-source 5G RAN implementation. Derived from the [ORAN-Bench-13K](https://arxiv.org/abs/2407.06245) dataset. Questions cover C++ classes, functions, libraries, configurations, and 3GPP specification details as implemented in srsRAN.
+
+## Usage
+
+```bash
+uv run inspect eval src/evals/srsranbench/srsranbench.py --model openai/gpt-4o
+```
+
+## Scoring
+
+Each question has one correct answer from 4 choices. The model's response is compared against the target answer using exact match.
+
+**Reference performance:** Gemini 3 Flash Preview achieves 82.8% accuracy on the full dataset.
+
+## Metrics
+
+- **accuracy**: Fraction of correct answers
+- **stderr**: Standard error of the accuracy estimate
+
+## Dataset Structure
+
+Each record contains:
+
+| Field | Description |
+|-------|-------------|
+| `question` | Multiple-choice question about srsRAN codebase |
+| `choices` | List of 4 answer candidates |
+| `answer` | Index (0-3) of correct answer |
+
+## Links
+
+- [Paper](https://arxiv.org/abs/2407.06245)
+- [Dataset](https://huggingface.co/datasets/prnshv/srsRANBench)
+- [srsRAN Project](https://github.com/srsran/srsRAN_Project)

--- a/src/evals/srsranbench/__init__.py
+++ b/src/evals/srsranbench/__init__.py
@@ -1,0 +1,3 @@
+from evals.srsranbench.srsranbench import srsranbench
+
+__all__ = ["srsranbench"]

--- a/src/evals/srsranbench/srsranbench.py
+++ b/src/evals/srsranbench/srsranbench.py
@@ -1,0 +1,39 @@
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample, hf_dataset
+from inspect_ai.scorer import choice
+from inspect_ai.solver import multiple_choice
+
+from evals._utils import resolve_dataset
+
+DEFAULT_DATASET = "GSMA/ot_sample_data"
+DEFAULT_DATASET_NAME = "srsranbench"
+DEFAULT_SPLIT = "test"
+
+
+def record_to_sample(record: dict) -> Sample:
+    """Convert dataset record to Sample."""
+    return Sample(
+        input=record["question"],
+        choices=record["choices"],
+        target=chr(65 + record["answer"]),
+    )
+
+
+@task
+def srsranbench(
+    dataset_path: str = DEFAULT_DATASET,
+    split: str = DEFAULT_SPLIT,
+    full: bool = False,
+) -> Task:
+    ds_path, ds_split = resolve_dataset(full, dataset_path, DEFAULT_DATASET, split)
+    dataset = hf_dataset(
+        ds_path,
+        name=DEFAULT_DATASET_NAME,
+        sample_fields=record_to_sample,
+        split=ds_split,
+    )
+    return Task(
+        dataset=dataset,
+        solver=multiple_choice(cot=False),
+        scorer=choice(),
+    )


### PR DESCRIPTION
## Summary

Adds two new evaluations derived from the [ORAN-Bench-13K](https://arxiv.org/abs/2407.06245) dataset:

- **ORANBench** — 1,500 MCQ on O-RAN Alliance specifications (easy/medium/hard)
- **srsRANBench** — 1,502 MCQ on the srsRAN 5G open-source codebase

Closes #41

## Changes

- New eval modules: `src/evals/oranbench/`, `src/evals/srsranbench/`
- Registered in `__init__.py`, `_registry.py`, `run_evals.py`
- Docs updated: eval list, quickstart, FAQ, running evaluations
- Full benchmark support via `-T full=true`

## Reference performance

| Benchmark | Model | Accuracy |
|-----------|-------|----------|
| ORANBench | RAG-based ORANSight | ~78% |
| srsRANBench | Gemini 3 Flash Preview | 82.8% |