### PR TITLE
fix(teletables): Update dataset path and add full benchmark support

### DIFF
--- a/src/evals/_utils.py
+++ b/src/evals/_utils.py
@@ -1,0 +1,24 @@
+"""Shared utilities for eval task functions."""
+
+FULL_DATASET = "GSMA/ot-full-benchmarks"
+
+
+def resolve_dataset(
+    full: bool,
+    dataset_path: str,
+    default_dataset: str,
+    split: str,
+) -> tuple[str, str]:
+    """Pick full or small dataset + split, respecting explicit overrides.
+
+    Returns ``(dataset_path, split)`` tuple.
+
+    If the caller passed a custom ``dataset_path`` (different from the
+    module's default), that explicit override always wins.  Otherwise
+    ``full=True`` switches to the full-benchmarks dataset.
+    """
+    if dataset_path != default_dataset:
+        return dataset_path, split  # explicit override wins
+    if full:
+        return FULL_DATASET, split
+    return default_dataset, split

--- a/src/evals/teletables/teletables.py
+++ b/src/evals/teletables/teletables.py
@@ -5,7 +5,9 @@ from inspect_ai.dataset import Sample, hf_dataset
 from inspect_ai.scorer import choice
 from inspect_ai.solver import multiple_choice
 
-DEFAULT_DATASET = "GSMA/open_telco"
+from evals._utils import resolve_dataset
+
+DEFAULT_DATASET = "GSMA/ot_sample_data"
 DEFAULT_DATASET_NAME = "teletables"
 DEFAULT_SPLIT = "test"
 
@@ -28,12 +30,14 @@ def record_to_sample(record: dict) -> Sample:
 def teletables(
     dataset_path: str = DEFAULT_DATASET,
     split: str = DEFAULT_SPLIT,
+    full: bool = False,
 ) -> Task:
+    ds_path, ds_split = resolve_dataset(full, dataset_path, DEFAULT_DATASET, split)
     dataset = hf_dataset(
-        dataset_path,
+        ds_path,
         name=DEFAULT_DATASET_NAME,
         sample_fields=record_to_sample,
-        split=split,
+        split=ds_split,
     )
     return Task(
         dataset=dataset,


### PR DESCRIPTION
## Summary

- Update teletables dataset from `GSMA/open_telco` to `GSMA/ot_sample_data`
- Add `full=True` parameter to switch to `GSMA/ot-full-benchmarks`
- Add shared `resolve_dataset()` utility in `_utils.py`

## Test plan

- [ ] `inspect eval src/evals/teletables/teletables.py --model openrouter/openai/gpt-4o-mini --limit 3`
- [ ] `inspect eval src/evals/teletables/teletables.py --model openrouter/openai/gpt-4o-mini --limit 3 -T full=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)