### PR TITLE
fix(run_evals): Add missing teletables task to eval set

### DIFF
--- a/src/evals/run_evals.py
+++ b/src/evals/run_evals.py
@@ -24,6 +24,7 @@ if __name__ == "__main__":
             "three_gpp/three_gpp.py",
             "teleqna/teleqna.py",
             "telemath/telemath.py",
+            "teletables/teletables.py",
             "oranbench/oranbench.py",
             "srsranbench/srsranbench.py",
         ],  # set how many tasks you want to run


### PR DESCRIPTION
## Summary
- Adds `teletables/teletables.py` to the `tasks` list in `run_evals.py`
- `teletables` was already registered in `__init__.py` but was missing from the runner script, causing it to be skipped when running the full evaluation suite via `python -m evals.run_evals`

Closes #45

## Test plan
- [ ] Verify `teletables` appears in task list when running `python -m evals.run_evals`
- [ ] Confirm other tasks are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)